### PR TITLE
Support projects using src folder in install script

### DIFF
--- a/install.js
+++ b/install.js
@@ -4,19 +4,25 @@ const copyRecursiveSync = require("./utilities/copyRecursiveSync");
 const copyFile = require("./utilities/copyFile");
 
 module.exports = () => {
+  const useSrc =
+    fs.existsSync(path.resolve(process.cwd()), "./src/app") ||
+    fs.existsSync(path.resolve(process.cwd()), "./src/pages");
+
+  const basePath = useSrc ? "./src" : ".";
+
   // Copy handlers into /api
   copyRecursiveSync(
     path.resolve(__dirname, "./templates/pages/api"),
-    path.resolve(process.cwd(), "./pages/api")
+    path.resolve(process.cwd(), `${basePath}/pages/api`)
   );
 
   // Copy admin into /app
   copyRecursiveSync(
     path.resolve(__dirname, "./templates/app"),
-    path.resolve(process.cwd(), "./app")
+    path.resolve(process.cwd(), `${basePath}/app`)
   );
 
-  const payloadConfigPath = path.resolve(process.cwd(), "./payload");
+  const payloadConfigPath = path.resolve(process.cwd(), `${basePath}/payload`);
 
   if (!fs.existsSync(payloadConfigPath)) {
     fs.mkdirSync(payloadConfigPath);
@@ -25,13 +31,13 @@ module.exports = () => {
   // Copy payload initialization
   copyFile(
     path.resolve(__dirname, "./templates/payloadClient.ts"),
-    path.resolve(process.cwd(), "./payload/payloadClient.ts")
+    path.resolve(process.cwd(), `${basePath}/payload/payloadClient.ts`)
   );
 
   // Copy base payload config
   copyFile(
     path.resolve(__dirname, "./templates/payload.config.ts"),
-    path.resolve(process.cwd(), "./payload/payload.config.ts")
+    path.resolve(process.cwd(), `${basePath}/payload/payload.config.ts`)
   );
 
   process.exit(0);


### PR DESCRIPTION
Some projects (including most of mine - who would've figured 😅) utilize [the `src` directory](https://nextjs.org/docs/advanced-features/src-directory) instead of putting `app` and/or `pages` in the root directory. This PR adds basic support for that in the install script by detecting if `src/app` or `src/pages` is present.