### PR TITLE
chore: removes serverComponentsExternalPackages from next config

### DIFF
--- a/withPayloadPlugin.js
+++ b/withPayloadPlugin.js
@@ -45,11 +45,6 @@ const withPayload = async (config, paths) => {
       ...config.experimental,
       appDir: true,
       outputFileTracingExcludes,
-      serverComponentsExternalPackages: [
-        ...(config?.experimental?.serverComponentsExternalPackages || []),
-        "mongoose",
-        "payload",
-      ],
     },
     webpack: (webpackConfig, webpackOptions) => {
       const incomingWebpackConfig =


### PR DESCRIPTION
This will no longer be needed if https://github.com/vercel/next.js/pull/51933 is merged released.