### PR TITLE
Adding Custom admin route option and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # Next + Payload Serverless
+
 This package contains a set of utilities to allow Payload to be deployed seamlessly, serverless, within an existing NextJS project. It adds the Payload admin UI into the NextJS `/app` folder and adds all Payload endpoints into the `pages/api` folder.
 
 To do so, this package exposes a few different helpers. To get started, follow the steps below:
 
 #### 1. Add this package and Payload to your project
+
 ```bash
 npm install @payloadcms/next-payload payload
 # or
@@ -19,6 +21,7 @@ yarn next-payload install
 ```
 
 #### 3. Your `.env` should include:
+
 ```env
 # mongo connection string
 MONGODB_URI=mongodb://localhost/create-next-app-serverless
@@ -34,24 +37,32 @@ Payload needs to inject some requirements into your Next config in order to func
 
 ```ts
 // next.config.js
-const path = require('path');
-const { withPayload } = require('@payloadcms/next-payload');
+const path = require("path");
+const { withPayload } = require("@payloadcms/next-payload");
 
-module.exports = withPayload({
-  // your Next config here
-}, {
-  // The second argument to `withPayload` 
-  // allows you to specify paths to your Payload dependencies.
-  
-  // Point to your Payload config (Required)
-  configPath: path.resolve(__dirname, './payload/payload.config.ts'),
-  
-  // Point to custom Payload CSS (optional)
-  cssPath: path.resolve(__dirname, './css/my-custom-payload-styles.css'),
-  
-  // Point to your exported, initialized Payload instance (optional, default shown below`)
-  payloadPath: path.resolve(process.cwd(), './payload/payloadClient.ts'),
-});
+module.exports = withPayload(
+  {
+    // your Next config here
+  },
+  {
+    // The second argument to `withPayload`
+    // allows you to specify paths to your Payload dependencies
+    // and configure the admin route to your Payload CMS.
+
+    // Point to your Payload config (Required)
+    configPath: path.resolve(__dirname, "./payload/payload.config.ts"),
+
+    // Point to custom Payload CSS (optional)
+    cssPath: path.resolve(__dirname, "./css/my-custom-payload-styles.css"),
+
+    // Point to your exported, initialized Payload instance (optional, default shown below`)
+    payloadPath: path.resolve(process.cwd(), "./payload/payloadClient.ts"),
+
+    // Set a custom Payload admin route (optional, default is `/admin`)
+    // IMPORTANT! If you want to configure a custom admin route, make sure to follow the additional instructions below
+    adminRoute: "/dashboard",
+  }
+);
 ```
 
 And then you're done. Have fun!
@@ -61,6 +72,7 @@ And then you're done. Have fun!
 The `payload/payloadClient.ts` file will be added for you after running `yarn next-payload install` (step 2). You can import `getPayloadClient` from that file from within server components to leverage the [Payloads Local API](https://payloadcms.com/docs/local-api/overview#local-api). The Local API does not use REST or GraphQL, and runs directly on your server talking directly to your database, which saves massively on HTTP-induced latency.
 
 Here is an example:
+
 ```ts
 // app/[slug]/page.tsx
 
@@ -100,6 +112,29 @@ export async function generateStaticParams() {
 
 export default Page;
 ```
+
+## Set a custom admin route
+
+Payload makes it simple to set a [custom `admin` route](https://payloadcms.com/docs/configuration/overview#options). However, since we are using `next-payload` and relying on Next.js to handle all routing, we need to also tell Next.js to rewrite all admin related routes to Payload.
+
+This is handled automatically by wrapping the Next.js configuration in `withPayload`, which by default sets the admin route to `/admin`. If you wish to change this default behavior, we need to do a couple of things.
+
+In the following example, we are changing the admin route to `/dashboard`.
+
+#### 1. Configure the `admin` route in `payload/payload.config.ts` as per the [Payload documentation](https://payloadcms.com/docs/configuration/overview#options).
+
+```ts
+export default buildConfig({
+  // ... Payload config goes here
+  routes: {
+    admin: "/dashboard",
+  },
+});
+```
+
+#### 2. Rename the `admin` directory under `/app` to `dashboard`.
+
+#### 3. Set `adminRoute: "/dashboard",` in the Payload configuration in `next.config.js` as per the documentation above.
 
 ## Known gotchas
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@payloadcms/next-payload",
   "description": "Payload deployed as Vercel functions within a NextJS app",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "license": "MIT",
   "author": {
     "email": "info@payloadcms.com",
@@ -41,7 +41,7 @@
     "webpack-filter-warnings-plugin": "^1.2.1"
   },
   "peerDependencies": {
-    "payload": "^1.7.1"
+    "payload": "^1.11.7"
   },
   "devDependencies": {
     "@swc/wasm": "^1.3.35",

--- a/withPayloadPlugin.js
+++ b/withPayloadPlugin.js
@@ -1,4 +1,5 @@
 const FilterWarningsPlugin = require("webpack-filter-warnings-plugin");
+const { getBaseConfig } = require("payload/dist/bundlers/webpack/configs/base");
 const path = require("path");
 const loadPayloadConfig = require("./loadPayloadConfig");
 const mockModulePath = path.resolve(__dirname, "./mocks/emptyModule.js");
@@ -12,7 +13,19 @@ const withPayload = async (config, paths) => {
     adminRoute = "/admin",
   } = paths || {};
 
-  const payloadConfig = await loadPayloadConfig(configPath);
+  let payloadConfig = await loadPayloadConfig(configPath);
+  payloadConfig = {
+    ...payloadConfig,
+    admin: {
+      ...payloadConfig.admin,
+      css: cssPath || customCSSMockPath,
+    },
+    paths: {
+      ...payloadConfig.paths,
+      rawConfig: configPath,
+    }
+  }
+  const payloadWebpackConfig = getBaseConfig(payloadConfig);
 
   const configRequiresSharp = payloadConfig.collections.find(({ upload }) => {
     if (typeof upload === "object" && upload !== null) {
@@ -86,9 +99,7 @@ const withPayload = async (config, paths) => {
             "@payloadcms/next-payload/getPayload":
               payloadPath ||
               path.resolve(process.cwd(), "./payload/payloadClient.ts"),
-            "payload-config": configPath,
-            payload$: mockModulePath,
-            "payload-user-css": cssPath || customCSSMockPath,
+            ...payloadWebpackConfig.resolve.alias,
           },
         },
       };

--- a/withPayloadPlugin.js
+++ b/withPayloadPlugin.js
@@ -45,7 +45,11 @@ const withPayload = async (config, paths) => {
       ...config.experimental,
       appDir: true,
       outputFileTracingExcludes,
-      serverComponentsExternalPackages: ["mongoose", "payload"],
+      serverComponentsExternalPackages: [
+        ...(config?.experimental?.serverComponentsExternalPackages || []),
+        "mongoose",
+        "payload",
+      ],
     },
     webpack: (webpackConfig, webpackOptions) => {
       const incomingWebpackConfig =

--- a/withPayloadPlugin.js
+++ b/withPayloadPlugin.js
@@ -5,7 +5,12 @@ const mockModulePath = path.resolve(__dirname, "./mocks/emptyModule.js");
 const customCSSMockPath = path.resolve(__dirname, "./mocks/custom.css");
 
 const withPayload = async (config, paths) => {
-  const { cssPath, payloadPath, configPath } = paths || {};
+  const {
+    cssPath,
+    payloadPath,
+    configPath,
+    adminRoute = "/admin",
+  } = paths || {};
 
   const payloadConfig = await loadPayloadConfig(configPath);
 
@@ -25,8 +30,8 @@ const withPayload = async (config, paths) => {
       "node_modules/@swc/wasm",
       "node_modules/webpack/**/*",
       ...(config.experimental &&
-        config.experimental.outputFileTracingExcludes &&
-        config.experimental.outputFileTracingExcludes["**/*"]
+      config.experimental.outputFileTracingExcludes &&
+      config.experimental.outputFileTracingExcludes["**/*"]
         ? config.experimental.outputFileTracingExcludes["**/*"]
         : []),
     ],
@@ -111,9 +116,11 @@ const withPayload = async (config, paths) => {
         userRewrites = await config.rewrites();
       }
 
+      // Cleaning up the admin route to make sure it's a valid path
+      const cleanedAdminRoute = adminRoute.split("/").filter(Boolean).join("/");
       const payloadAdminRewrite = {
-        source: "/admin/:path*",
-        destination: "/admin",
+        source: "/" + cleanedAdminRoute + "/:path*",
+        destination: "/" + cleanedAdminRoute,
       };
 
       if (Array.isArray(userRewrites)) {


### PR DESCRIPTION
This update allows for developers to set the admin route as a configuration parameter within Next.js payload config and provides instructions on how to properly set up custom admin routes in next-payload.