### PR TITLE
feat: add support for custom endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,19 @@ export default buildConfig({
 
 ## Known gotchas
 
+#### Custom endpoint handlers
+
+To use custom endpoints Next.JS requires you to put a path segment in between two dynamic route parameters. Therefore it is necessary to add some segment, which defaults to `endpoints`. This can be adjusted through editing the name of the folder.
+
+##### Example API call
+
+```ts
+// Expected
+const data = await fetch('https://YOUR_CUSTOM_URL/api/[collection]/[...path]');
+// Required change
+const data = await fetch('https://YOUR_CUSTOM_URL/api/[collection]/endpoints/[...path]');
+```
+
 #### Cold start delays
 
 With the nature of serverless functions, you are bound to encounter "cold start" delays when your serverless functions spin up for the first time. Once they're "warm", the problem will go away for a few minutes until the functions become dormant again. But there's little that this package can do about that issue, unfortunately.

--- a/src/handlers/[collection]/endpoints/[...path].ts
+++ b/src/handlers/[collection]/endpoints/[...path].ts
@@ -1,0 +1,117 @@
+import authenticate from '../../../middleware/authenticate';
+import convertPayloadJSONBody from '../../../middleware/convertPayloadJSONBody';
+import withDataLoader from '../../../middleware/dataLoader';
+import fileUpload from '../../../middleware/fileUpload';
+import i18n from '../../../middleware/i18n';
+import initializePassport from '../../../middleware/initializePassport';
+import withPayload from '../../../middleware/withPayload';
+import { Response } from 'express';
+import httpStatus from 'http-status';
+import { Endpoint } from 'payload/config';
+import NotFound from 'payload/dist/errors/NotFound';
+import getErrorHandler from 'payload/dist/express/middleware/errorHandler';
+import { PayloadRequest } from 'payload/types';
+
+/**
+ * Execute the handler(s) of the given endpoint.
+ */
+async function executeHandler(
+  endpoint: Endpoint,
+  req: PayloadRequest,
+  res: Response,
+) {
+  if (Array.isArray(endpoint.handler)) {
+    return Promise.all(
+      endpoint.handler.map((handler) => {
+        return handler(req, res, () => null);
+      }),
+    );
+  } else {
+    return endpoint.handler(req, res, () => null);
+  }
+}
+
+/**
+ * Checks if the given request satisfies the handler. If so,
+ * it returns the required arguments for the handler.
+ *
+ * @param expectedEndpoint - The endpoint that is expected to have been called.
+ * @param actualRequest - The request that has actually been send.
+ */
+function isCorrectEndpoint(
+  expectedEndpoint: Omit<Endpoint, 'root'>,
+  actualRequest: PayloadRequest,
+): false | Record<string, any> {
+  // Make sure the request method is the expected one
+  if (expectedEndpoint.method.toUpperCase() !== actualRequest.method) {
+    return false;
+  }
+
+  return validatePath(actualRequest, expectedEndpoint);
+}
+
+/**
+ * Create params and validate that the request belongs to the endpoint.
+ * @param req - The request that has been made.
+ * @param endpoint - The endpoint to check.
+ */
+function validatePath(req: PayloadRequest, endpoint: Endpoint) {
+  const pathSegments = endpoint.path.split('/').filter(Boolean);
+  const params = {};
+
+  for (let i = 0; i < pathSegments.length; i++) {
+    const segment = pathSegments[i];
+
+    if (segment.startsWith(':')) {
+      params[segment.substring(1)] = req.query?.path?.[i];
+    } else if (segment !== req.query?.path?.[i]) {
+      return false;
+    }
+  }
+
+  return params;
+}
+
+async function handler(req: PayloadRequest, res: Response) {
+  const collectionSlug = typeof req?.query?.collection === 'string' ? req.query.collection : undefined;
+
+  if (collectionSlug === undefined || req.payload.collections[collectionSlug] === undefined) {
+    return res.status(httpStatus.BAD_REQUEST).json({
+      message: 'Collection not found',
+    })
+  }
+
+  const { endpoints } = req.payload.collections[collectionSlug].config
+
+  // Catch all errors that could occur in execution of custom handlers.
+  try {
+    for (const endpoint of endpoints) {
+      const params = isCorrectEndpoint(endpoint, req)
+  
+      if (params !== false) {
+        return executeHandler(endpoint, { ...req, params } as PayloadRequest, res)
+      }
+    }
+  } catch (error) {
+    const errorHandler = getErrorHandler(req.payload.config, req.payload.logger)
+    return errorHandler(error, req, res, () => null)
+  }
+
+  return res.status(httpStatus.NOT_FOUND).json(new NotFound(req.t))
+}
+
+export default withPayload(
+  withDataLoader(
+    fileUpload(
+      convertPayloadJSONBody(
+        i18n(
+          initializePassport(
+            authenticate(
+              handler
+            )
+          )
+        )
+      )
+    )
+  )
+)

--- a/templates/pages/api/[collection]/endpoints/[...path].ts
+++ b/templates/pages/api/[collection]/endpoints/[...path].ts
@@ -1,0 +1,10 @@
+import handler from '@payloadcms/next-payload/dist/handlers/[collection]/endpoints/[...path]'
+
+export default handler
+
+export const config = {
+  api: {
+    bodyParser: false,
+    externalResolver: true,
+  }
+}


### PR DESCRIPTION
## Description

This PR adds support for custom endpoints with Next.JS.

The addition is draft in nature. It is fully functional (I'm already using it in production), but I would love to hear feedback and make the corresponding edits.

### Aspects that should be mentioned

- When deployed to Vercel, it is necessary to have a path segment in between `[collection]` and the actual path handler. Therefore custom endpoints do not work exactly as expected.

- Support for multiple endpoints with the same path is limited

## Type of change

[x] This change requires a documentation update
